### PR TITLE
Supports #with_order method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ User.find([3, 1, 5]).map(&:id)
 User.find_with_order([3, 1, 5]).map(&:id)
 # => [3, 1, 5] 
 ```
+
 ### Support order other columns
 ```rb
 User.where(name: %w(Pearl John Kathenrie)).pluck(:name)
@@ -43,6 +44,16 @@ User.where(name: %w(Pearl John Kathenrie)).pluck(:name)
 User.where_with_order(:name, %w(Pearl John Kathenrie)).pluck(:name)
 # => ['Pearl', 'John', 'Kathenrie']
 ```
+
+### Just order part of results
+```rb
+User.where(leader: true).with_order(:name, %w(Pearl John)).pluck(:name)
+# => ['Pearl', 'John', 'Kathenrie']
+
+User.where(leader: true).with_order(:name, %w(Pearl John), null_first: true).pluck(:name)
+# => ['Kathenrie', 'Pearl', 'John']
+```
+
 
 ## Benchmark
 ### Compare with manually sorting in rails

--- a/lib/find_with_order.rb
+++ b/lib/find_with_order.rb
@@ -23,8 +23,8 @@ class << ActiveRecord::Base
     return FindWithOrder.supporter.where_with_order(self, column, ids.uniq)
   end
 
-  def with_order(column, ids)
-    FindWithOrder.supporter.with_order(self, column, ids)
+  def with_order(column, ids, null_first: false)
+    FindWithOrder.supporter.with_order(self, column, ids, null_first: null_first)
   end
 end
 

--- a/lib/find_with_order/mysql_support.rb
+++ b/lib/find_with_order/mysql_support.rb
@@ -1,17 +1,15 @@
-module FindWithOrder
-  module MysqlSupport
-    class << self
-      def find_with_order(relation, ids)
-        return relation.where(id: ids).order("field(#{relation.table_name}.id, #{ids.join(',')})").to_a
-      end
+module FindWithOrder::MysqlSupport
+  class << self
+    def find_with_order(relation, ids)
+      return relation.where(id: ids).order("field(#{relation.table_name}.id, #{ids.join(',')})").to_a
+    end
 
-      def where_with_order(relation, column, ids)
-        return relation.where(column => ids).order("field(#{column}, #{ids.map(&:inspect).join(',')})")
-      end
+    def where_with_order(relation, column, ids)
+      return relation.where(column => ids).order("field(#{column}, #{ids.map(&:inspect).join(',')})")
+    end
 
-      def with_order(relation, column, ids)
-        relation.order("field(#{column}, #{ids.map(&:inspect).join(',')})")
-      end
+    def with_order(relation, column, ids)
+      relation.order("field(#{column}, #{ids.map(&:inspect).join(',')})")
     end
   end
 end

--- a/lib/find_with_order/mysql_support.rb
+++ b/lib/find_with_order/mysql_support.rb
@@ -1,11 +1,13 @@
 module FindWithOrder::MysqlSupport
   class << self
     def find_with_order(relation, ids)
-      return relation.where(id: ids).order("field(#{relation.table_name}.id, #{ids.join(',')})").to_a
+      relation.where(id: ids)
+              .order("field(#{relation.table_name}.id, #{ids.join(',')})")
+              .to_a
     end
 
     def where_with_order(relation, column, ids)
-      return relation.where(column => ids).order("field(#{column}, #{ids.map(&:inspect).join(',')})")
+      with_order(relation.where(column => ids), column, ids)
     end
 
     def with_order(relation, column, ids)

--- a/lib/find_with_order/mysql_support.rb
+++ b/lib/find_with_order/mysql_support.rb
@@ -7,11 +7,12 @@ module FindWithOrder::MysqlSupport
     end
 
     def where_with_order(relation, column, ids)
-      with_order(relation.where(column => ids), column, ids)
+      with_order(relation.where(column => ids), column, ids, null_first: true)
     end
 
-    def with_order(relation, column, ids)
-      relation.order("field(#{column}, #{ids.map(&:inspect).join(',')})")
+    def with_order(relation, column, ids, null_first: false)
+      return relation.order("field(#{column}, #{ids.map(&:inspect).join(',')})") if null_first 
+      return relation.order("field(#{column}, #{ids.reverse.map(&:inspect).join(',')}) DESC")
     end
   end
 end

--- a/lib/find_with_order/mysql_support.rb
+++ b/lib/find_with_order/mysql_support.rb
@@ -1,10 +1,17 @@
 module FindWithOrder
   module MysqlSupport
-    def self.find_with_order(relation, ids)
-      return relation.where(id: ids).order("field(#{relation.table_name}.id, #{ids.join(',')})").to_a
-    end
-    def self.where_with_order(relation, column, ids)
-      return relation.where(column => ids).order("field(#{column}, #{ids.map(&:inspect).join(',')})")
+    class << self
+      def find_with_order(relation, ids)
+        return relation.where(id: ids).order("field(#{relation.table_name}.id, #{ids.join(',')})").to_a
+      end
+
+      def where_with_order(relation, column, ids)
+        return relation.where(column => ids).order("field(#{column}, #{ids.map(&:inspect).join(',')})")
+      end
+
+      def with_order(relation, column, ids)
+        relation.order("field(#{column}, #{ids.map(&:inspect).join(',')})")
+      end
     end
   end
 end

--- a/lib/find_with_order/pg_support.rb
+++ b/lib/find_with_order/pg_support.rb
@@ -1,13 +1,30 @@
-module FindWithOrder
-  module PGSupport
-    def self.find_with_order(relation, ids)
+module FindWithOrder::PGSupport
+  class << self
+    def find_with_order(relation, ids)
       # return relation.where(id: ids).order("array_position(ARRAY[#{ids.join(',')}], #{relation.table_name}.id)").to_a #array_position is only support in PG >= 9.5
       return relation.where(id: ids)
                      .joins("JOIN (SELECT id.val, row_number() over() FROM (VALUES(#{ids.join('),(')})) AS id(val)) AS id ON (#{relation.table_name}.id = id.val)")
                      .order('row_number')
     end
-    def self.where_with_order(relation, column, ids)
+
+    def where_with_order(relation, column, ids)
       relation = relation.where(column => ids)
+      case ids.first
+      when Numeric
+        # return relation.order("array_position(ARRAY[#{ids.join(',')}], #{column})") #array_position is only support in PG >= 9.5
+        return relation.joins("JOIN (SELECT id.val, row_number() over() FROM (VALUES(#{ids.join('),(')})) AS id(val)) AS id ON (#{column} = id.val)")
+                       .order('row_number')
+      when String
+        ids.map!{|s| ActiveRecord::Base.connection.quote_string(s) }
+        # return relation.order("array_position(ARRAY['#{ids.join("','")}']::varchar[], #{column})") #array_position is only support in PG >= 9.5
+        return relation.joins("JOIN (SELECT id.val, row_number() over() FROM (VALUES('#{ids.join("'),('")}')) AS id(val)) AS id ON (#{column} = id.val)")
+                       .order('row_number')
+      else
+        raise "not support type: #{ids.first.class}"
+      end
+    end
+
+    def with_order(relation, column, ids)
       case ids.first
       when Numeric
         # return relation.order("array_position(ARRAY[#{ids.join(',')}], #{column})") #array_position is only support in PG >= 9.5

--- a/lib/find_with_order/pg_support.rb
+++ b/lib/find_with_order/pg_support.rb
@@ -11,20 +11,20 @@ module FindWithOrder::PGSupport
       with_order(relation.where(column => ids), column, ids)
     end
 
-    def with_order(relation, column, ids)
+    def with_order(relation, column, ids, null_first: false)
       case ids.first
       when Numeric
+        values = ids.join('),(')
         # return relation.order("array_position(ARRAY[#{ids.join(',')}], #{column})") #array_position is only support in PG >= 9.5
-        return relation.joins("JOIN (SELECT id.val, row_number() over() FROM (VALUES(#{ids.join('),(')})) AS id(val)) AS id ON (#{column} = id.val)")
-                       .order('row_number')
       when String
         ids.map!{|s| ActiveRecord::Base.connection.quote_string(s) }
+        values = "'#{ids.join("'),('")}'"
         # return relation.order("array_position(ARRAY['#{ids.join("','")}']::varchar[], #{column})") #array_position is only support in PG >= 9.5
-        return relation.joins("JOIN (SELECT id.val, row_number() over() FROM (VALUES('#{ids.join("'),('")}')) AS id(val)) AS id ON (#{column} = id.val)")
-                       .order('row_number')
       else
         raise "not support type: #{ids.first.class}"
       end
+      return relation.joins("LEFT JOIN (SELECT id.val, row_number() over() FROM (VALUES(#{values})) AS id(val)) AS id ON (#{column} = id.val)")
+                     .order('row_number')
     end
   end
 end

--- a/lib/find_with_order/pg_support.rb
+++ b/lib/find_with_order/pg_support.rb
@@ -12,6 +12,7 @@ module FindWithOrder::PGSupport
     end
 
     def with_order(relation, column, ids, null_first: false)
+      ids = ids.reverse if null_first
       case ids.first
       when Numeric
         values = ids.join('),(')
@@ -24,7 +25,7 @@ module FindWithOrder::PGSupport
         raise "not support type: #{ids.first.class}"
       end
       return relation.joins("LEFT JOIN (SELECT id.val, row_number() over() FROM (VALUES(#{values})) AS id(val)) AS id ON (#{column} = id.val)")
-                     .order('row_number')
+                     .order(null_first ? 'row_number DESC' : 'row_number')
     end
   end
 end

--- a/test/find_with_order_test.rb
+++ b/test/find_with_order_test.rb
@@ -74,6 +74,15 @@ class FindWithOrderTest < Minitest::Test
     assert_equal [3, 1, 2], users.with_order(:id, [3, 1]).pluck(:id)
     assert_equal [2, 3, 1], users.with_order(:id, [3, 1], null_first: true).pluck(:id)
   end
+
+  def test_order_with_different_column
+    posts = Post.joins(:user).where(:'users.name' => 'John')
+    expected_order = ["John's post3", "John's post1", "John's post2"]
+    assert_equal expected_order, posts.with_order(:title, ["John's post3", "John's post1"]).pluck(:'posts.title')
+
+    expected_order = ["John's post2", "John's post3", "John's post1"]
+    assert_equal expected_order, posts.with_order(:title, ["John's post3", "John's post1"], null_first: true).pluck(:'posts.title')
+  end
 end
 
 

--- a/test/find_with_order_test.rb
+++ b/test/find_with_order_test.rb
@@ -71,6 +71,7 @@ class FindWithOrderTest < Minitest::Test
 
   def test_with_order
     assert_equal [3, 1, 2], User.where(id: [1, 2, 3]).with_order(:id, [3, 1]).pluck(:id)
+    assert_equal [2, 3, 1], User.where(id: [1, 2, 3]).with_order(:id, [3, 1], null_first: true).pluck(:id)
   end
 end
 

--- a/test/find_with_order_test.rb
+++ b/test/find_with_order_test.rb
@@ -70,8 +70,9 @@ class FindWithOrderTest < Minitest::Test
   end
 
   def test_with_order
-    assert_equal [3, 1, 2], User.where(id: [1, 2, 3]).with_order(:id, [3, 1]).pluck(:id)
-    assert_equal [2, 3, 1], User.where(id: [1, 2, 3]).with_order(:id, [3, 1], null_first: true).pluck(:id)
+    users = User.where(id: [1, 2, 3])
+    assert_equal [3, 1, 2], users.with_order(:id, [3, 1]).pluck(:id)
+    assert_equal [2, 3, 1], users.with_order(:id, [3, 1], null_first: true).pluck(:id)
   end
 end
 

--- a/test/find_with_order_test.rb
+++ b/test/find_with_order_test.rb
@@ -68,6 +68,10 @@ class FindWithOrderTest < Minitest::Test
     assert_equal order, User.joins(:posts).find_with_order(order).map(&:id).uniq #postgresql doesn't support distinct + order
     assert_equal order, User.joins(:posts).where_with_order(:'users.id', order).pluck(:id).uniq
   end
+
+  def test_with_order
+    assert_equal [3, 1, 2], User.where(id: [1, 2, 3]).with_order(:id, [3, 1]).pluck(:id)
+  end
 end
 
 


### PR DESCRIPTION
### Allowing just order without WHERE condition
```rb
User.where(leader: true).with_order(:name, %w(Pearl John)).pluck(:name)
# => ['Pearl', 'John', 'Kathenrie']

User.where(leader: true).with_order(:name, %w(Pearl John), null_first: true).pluck(:name)
# => ['Kathenrie', 'Pearl', 'John']
```