### PR TITLE
Wrapping raw SQL in Arel.sql() 

### DIFF
--- a/lib/find_with_order/mysql_support.rb
+++ b/lib/find_with_order/mysql_support.rb
@@ -4,7 +4,7 @@ module FindWithOrder::MysqlSupport
   class << self
     def find_with_order(relation, ids)
       relation.where(id: ids)
-              .order("field(#{relation.table_name}.id, #{ids.join(',')})")
+              .order(Arel.sql("field(#{relation.table_name}.id, #{ids.join(',')})"))
               .to_a
     end
 
@@ -18,8 +18,8 @@ module FindWithOrder::MysqlSupport
       else
         column = column.to_s
       end
-      return relation.order("field(#{column}, #{ids.map(&:inspect).join(',')})") if null_first 
-      return relation.order("field(#{column}, #{ids.reverse.map(&:inspect).join(',')}) DESC")
+      return relation.order(Arel.sql("field(#{column}, #{ids.map(&:inspect).join(',')})")) if null_first
+      return relation.order(Arel.sql("field(#{column}, #{ids.reverse.map(&:inspect).join(',')}) DESC"))
     end
   end
 end


### PR DESCRIPTION
Since Rails 5.2 https://github.com/rails/rails/pull/27947, some kind of raw SQL in `ActiveRecord::QueryMethods#order` should be wrapped in `Arel.sql()` or will get `DEPRECATION WARNING`. And Since Rails 6.1  https://github.com/rails/rails/commit/317465a4a8f8c0ebaf9534921350c4540584c03c, it will raise `ActiveRecord::UnknownAttributeReference` error anyway.
This PR wrapping raw SQL in `Arel.sql()` for MySQL SQLs. It should be fine for PostgreSQL SQLs.